### PR TITLE
Add VAE text style transfer training pipeline (tst-training-v2)

### DIFF
--- a/code/tst-training-v2/config.py
+++ b/code/tst-training-v2/config.py
@@ -1,0 +1,142 @@
+"""
+config.py — Central configuration for the Text Style Transfer VAE.
+
+All hyperparameters live here so nothing is scattered across notebooks.
+Adjust values based on your GPU (V100 32GB vs A100 40/80GB).
+
+Architecture overview:
+    Input text
+    → LLaMA 3.1 8B tokenizer (128K BPE vocab)
+    → LLaMA 3.1 8B frozen embedding (128256 × 4096)
+    → Projection layer (4096 → d_model=512)
+    → Transformer encoder (4 layers, 8 heads)
+    → Masked mean pool → content μ/logσ², style μ/logσ²
+    → Reparameterize → z_c (128-dim), z_s (32-dim)
+    → Concatenate [z_c; z_s] → project to d_model
+    → Autoregressive Transformer decoder (4 layers, causal self-attention only)
+    → Output projection → vocab logits (128256)
+
+Loss = Reconstruction + β·KL + γ·HSIC(z_c, z_s) + λ·Contrastive(z_s)
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class ModelConfig:
+    """Architecture hyperparameters."""
+
+    # --- Pretrained model ---
+    llama_model_name: str = "meta-llama/Llama-3.1-8B"
+    llama_embed_dim: int = 4096          # LLaMA 3.1 8B embedding dimension
+    llama_vocab_size: int = 128256       # Actual vocab size (128K + special tokens)
+
+    # --- Projection ---
+    # We project LLaMA's 4096-dim embeddings down to d_model to make the
+    # transformer layers feasible on a single GPU. Without this, a 6-layer
+    # transformer at d_model=4096 would consume ~20GB+ for moderate batch sizes.
+    d_model: int = 512                   # Working dimension after projection
+
+    # --- Transformer encoder/decoder ---
+    n_heads: int = 8                     # Attention heads (head_dim = 512/8 = 64)
+    n_encoder_layers: int = 6            # Encoder depth
+    n_decoder_layers: int = 6            # Decoder depth
+    dim_feedforward: int = 2048          # FFN hidden dim (4× d_model is standard)
+    dropout: float = 0.1                 # Dropout in transformer layers
+
+    # --- Latent space ---
+    # Content latent encodes *what* was said (semantics, entities, relationships).
+    # Style latent encodes *how* it was said (Shakespeare vs modern).
+    # Content needs more capacity because semantic meaning is higher-dimensional.
+    # John et al. used content=128, style=8. We use style=32 because
+    # Shakespeare style is richer than binary sentiment (archaic vocabulary,
+    # inverted syntax, thee/thou pronouns, etc.)
+    content_latent_dim: int = 128
+    style_latent_dim: int = 32
+
+    # --- Sequence length ---
+    max_seq_len: int = 128               # LLaMA BPE produces longer seqs than word-level
+
+    # --- Derived ---
+    @property
+    def total_latent_dim(self) -> int:
+        return self.content_latent_dim + self.style_latent_dim
+
+
+@dataclass
+class TrainConfig:
+    """Training hyperparameters."""
+
+    # --- Optimization ---
+    batch_size: int = 32                 # Adjust for your GPU memory
+    learning_rate: float = 1e-3          # AdamW learning rate
+    weight_decay: float = 0.01           # AdamW weight decay
+    max_grad_norm: float = 1.0           # Gradient clipping
+    num_epochs: int = 30                 # Total training epochs
+
+    # --- KL annealing ---
+    # Without annealing, the KL term dominates early in training and pushes
+    # the posterior q(z|x) to match the prior N(0,I) before the decoder has
+    # learned to use z. This is "posterior collapse" — z becomes noise and the
+    # decoder ignores it. Sigmoid annealing starts with β≈0 (letting the model
+    # learn reconstruction first) and slowly increases β to 1.0.
+    kl_anneal_steps: int = 20000         # Steps to reach β≈1.0 # doubled 
+    kl_anneal_midpoint: int = 10_000       # Step where β=0.5 (inflection point) #doubled 
+    kl_anneal_steepness: float = 0.002   # Controls sigmoid sharpness
+
+    # --- Loss weights ---
+    # γ (gamma_hsic): Weight for HSIC independence loss.
+    #   HSIC measures statistical dependence between z_c and z_s.
+    #   Higher γ = stronger push for independence, but too high starves
+    #   the model of capacity (can't encode anything if forced to be
+    #   perfectly independent).
+    gamma_hsic: float = 0.5
+
+    # λ (lambda_contrast): Weight for contrastive style loss.
+    #   Pulls same-style z_s vectors together, pushes different-style apart.
+    #   Higher λ = tighter style clusters, but too high can cause z_s to
+    #   memorize style labels rather than learning a smooth manifold.
+    lambda_contrast: float = 0.3 # 1, 0,5, 0.3
+
+    # Temperature for contrastive loss (lower = sharper similarities)
+    contrastive_temperature: float = 0.1
+
+    # --- Learning rate schedule ---
+    warmup_steps: int = 500              # Linear warmup before cosine decay
+    min_lr_ratio: float = 0.01           # Minimum LR as fraction of peak LR
+
+    # --- Logging & checkpointing ---
+    log_every: int = 50                  # Log metrics every N steps
+    eval_every: int = 500                # Run validation every N steps
+    save_every: int = 10_000               # Save checkpoint every N steps
+
+
+@dataclass
+class DataConfig:
+    """Data pipeline configuration."""
+
+    # --- Paths (relative to project root) ---
+    # These point to the Shakespearizing-Modern-English .nltktok files.
+    # The data is pre-tokenized at the word level by nltk — we rejoin
+    # words into strings and let LLaMA's BPE tokenizer re-tokenize.
+    data_dir: str = "/projectnb/scottml/seansal2/data/Shakespearizing-Modern-English/data"
+
+    train_modern: str = "train.modern.nltktok"
+    train_original: str = "train.original.nltktok"
+    valid_modern: str = "valid.modern.nltktok"
+    valid_original: str = "valid.original.nltktok"
+    test_modern: str = "test.modern.nltktok"
+    test_original: str = "test.original.nltktok"
+
+    # --- Style labels ---
+    # 0 = modern English, 1 = Shakespeare
+    modern_label: int = 0
+    shakespeare_label: int = 1
+    num_styles: int = 2
+
+    # --- Checkpoint/output directory ---
+    output_dir: str = "checkpoints"
+
+    def get_path(self, filename: str) -> Path:
+        return Path(self.data_dir) / filename

--- a/code/tst-training-v2/data.py
+++ b/code/tst-training-v2/data.py
@@ -1,0 +1,287 @@
+"""
+data.py — Data loading pipeline for the Text Style Transfer VAE.
+
+Two dataset classes:
+  1. StyleDataset     — For training (non-parallel). Combines modern + Shakespeare
+                        sentences into a flat list with style labels. This is what
+                        the professor's train() function expects.
+  2. ParallelEvalDataset — For evaluation only. Keeps the sentence pairing so we
+                           can compute BLEU between generated output and ground truth.
+
+Tokenization strategy:
+  - The .nltktok files contain word-tokenized text (spaces between all tokens,
+    including punctuation: "I have a mind to strike thee ere thou speak'st .")
+  - We rejoin tokens into strings with " ".join() and let LLaMA's BPE tokenizer
+    handle everything. The custom vocab code from transformer_vae.ipynb is discarded.
+  - LLaMA's tokenizer handles padding, BOS/EOS, and subword splitting natively.
+  - The extra spaces around punctuation from nltk are consistent across both styles,
+    so the model sees the same patterns on both sides. Post-processing at inference
+    time strips these artifacts.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import torch
+from torch.utils.data import Dataset, DataLoader
+from transformers import AutoTokenizer
+
+from config import DataConfig, ModelConfig
+
+
+# ──────────────────────────────────────────────────────────
+# File I/O
+# ──────────────────────────────────────────────────────────
+
+def load_sentences(filepath: str | Path) -> list[str]:
+    """
+    Load a .nltktok file and rejoin tokens into plain strings.
+
+    Each line is a space-separated list of nltk-tokenized words.
+    We join them back into a string that the LLaMA tokenizer can process.
+
+    Example line in file:  "I have a mind to strike thee ere thou speak'st ."
+    Returned string:       "I have a mind to strike thee ere thou speak'st ."
+    (Same — the join is a no-op since it's already space-separated.)
+    """
+    filepath = Path(filepath)
+    sentences = []
+    with open(filepath, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                sentences.append(line)
+    return sentences
+
+
+# ──────────────────────────────────────────────────────────
+# Training dataset (non-parallel)
+# ──────────────────────────────────────────────────────────
+
+class StyleDataset(Dataset):
+    """
+    Flat dataset of sentences with style labels for non-parallel training.
+
+    Combines all modern sentences (label=0) and all Shakespeare sentences
+    (label=1) into one shuffled dataset. The model never sees which modern
+    sentence corresponds to which Shakespeare sentence — it just learns
+    that some sentences are modern and some are Shakespeare.
+
+    Each item returns a dict with:
+        - "text": raw string (will be tokenized in collate_fn)
+        - "doc_id": style label (0=modern, 1=Shakespeare)
+
+    This matches the batch format expected by the train() function in
+    transformer_vae_original.ipynb: batch["text"] and batch["doc_id"].
+    """
+
+    def __init__(self, modern_sents: list[str], original_sents: list[str],
+                 data_config: DataConfig):
+        self.texts: list[str] = []
+        self.labels: list[int] = []
+
+        for sent in modern_sents:
+            self.texts.append(sent)
+            self.labels.append(data_config.modern_label)
+
+        for sent in original_sents:
+            self.texts.append(sent)
+            self.labels.append(data_config.shakespeare_label)
+
+    def __len__(self) -> int:
+        return len(self.texts)
+
+    def __getitem__(self, idx: int) -> dict:
+        return {
+            "text": self.texts[idx],
+            "doc_id": self.labels[idx],
+        }
+
+
+# ──────────────────────────────────────────────────────────
+# Evaluation dataset (parallel)
+# ──────────────────────────────────────────────────────────
+
+class ParallelEvalDataset(Dataset):
+    """
+    Paired dataset for evaluation only.
+
+    Keeps the 1:1 correspondence between modern and Shakespeare sentences
+    so we can:
+      1. Encode the modern sentence → extract z_c
+      2. Combine with average Shakespeare z_s → decode
+      3. Compare generated output to ground-truth Shakespeare (BLEU)
+
+    NOT used during training.
+    """
+
+    def __init__(self, modern_sents: list[str], original_sents: list[str]):
+        assert len(modern_sents) == len(original_sents), (
+            f"Parallel data must be aligned: got {len(modern_sents)} modern "
+            f"vs {len(original_sents)} original"
+        )
+        self.modern = modern_sents
+        self.original = original_sents
+
+    def __len__(self) -> int:
+        return len(self.modern)
+
+    def __getitem__(self, idx: int) -> dict:
+        return {
+            "modern": self.modern[idx],
+            "original": self.original[idx],
+        }
+
+
+# ──────────────────────────────────────────────────────────
+# Collate functions
+# ──────────────────────────────────────────────────────────
+
+def make_train_collate_fn(tokenizer: AutoTokenizer, max_seq_len: int):
+    """
+    Returns a collate function that tokenizes raw strings on the fly.
+
+    Why tokenize in collate_fn rather than in __getitem__?
+    - Dynamic padding: each batch is padded to its own max length, not the
+      global max_seq_len. This saves compute on short batches.
+    - No need to store 37K pre-tokenized tensors in memory.
+    - The tokenizer call is batched (faster than per-sample).
+
+    The returned batch dict contains:
+        - "input_ids":      (batch, seq_len) — token IDs for the model
+        - "attention_mask": (batch, seq_len) — 1 for real tokens, 0 for padding
+        - "doc_ids":        (batch,)         — style labels
+    """
+
+    def collate_fn(samples: list[dict]) -> dict:
+        texts = [s["text"] for s in samples]
+        doc_ids = torch.tensor([s["doc_id"] for s in samples], dtype=torch.long)
+
+        # Tokenize the whole batch at once
+        encoded = tokenizer(
+            texts,
+            padding=True,               # Pad to longest in batch
+            truncation=True,             # Truncate to max_seq_len
+            max_length=max_seq_len,
+            return_tensors="pt",
+        )
+
+        return {
+            "input_ids": encoded["input_ids"],           # (batch, seq_len)
+            "attention_mask": encoded["attention_mask"],  # (batch, seq_len)
+            "doc_ids": doc_ids,                          # (batch,)
+        }
+
+    return collate_fn
+
+
+def make_eval_collate_fn(tokenizer: AutoTokenizer, max_seq_len: int):
+    """
+    Collate function for the parallel evaluation dataset.
+
+    Tokenizes both modern and original sentences so we can:
+    - Encode the modern sentence through the VAE
+    - Have ground-truth original token IDs for BLEU comparison
+    """
+
+    def collate_fn(samples: list[dict]) -> dict:
+        modern_texts = [s["modern"] for s in samples]
+        original_texts = [s["original"] for s in samples]
+
+        modern_enc = tokenizer(
+            modern_texts,
+            padding=True,
+            truncation=True,
+            max_length=max_seq_len,
+            return_tensors="pt",
+        )
+        original_enc = tokenizer(
+            original_texts,
+            padding=True,
+            truncation=True,
+            max_length=max_seq_len,
+            return_tensors="pt",
+        )
+
+        return {
+            "modern_input_ids": modern_enc["input_ids"],
+            "modern_attention_mask": modern_enc["attention_mask"],
+            "original_input_ids": original_enc["input_ids"],
+            "original_attention_mask": original_enc["attention_mask"],
+            "modern_texts": modern_texts,
+            "original_texts": original_texts,
+        }
+
+    return collate_fn
+
+
+# ──────────────────────────────────────────────────────────
+# Convenience: build all dataloaders
+# ──────────────────────────────────────────────────────────
+
+def build_dataloaders(
+    data_config: DataConfig,
+    model_config: ModelConfig,
+    tokenizer: AutoTokenizer,
+    batch_size: int,
+    num_workers: int = 2,
+) -> dict:
+    """
+    Build train, validation, and test dataloaders.
+
+    Returns a dict with keys: "train", "valid", "test_eval"
+    - "train" and "valid" use StyleDataset (non-parallel, shuffled)
+    - "test_eval" uses ParallelEvalDataset (parallel, for BLEU evaluation)
+    """
+    # Load raw sentences
+    train_modern = load_sentences(data_config.get_path(data_config.train_modern))
+    train_original = load_sentences(data_config.get_path(data_config.train_original))
+    valid_modern = load_sentences(data_config.get_path(data_config.valid_modern))
+    valid_original = load_sentences(data_config.get_path(data_config.valid_original))
+    test_modern = load_sentences(data_config.get_path(data_config.test_modern))
+    test_original = load_sentences(data_config.get_path(data_config.test_original))
+
+    print(f"Loaded data — Train: {len(train_modern)} modern + {len(train_original)} shakespeare")
+    print(f"              Valid: {len(valid_modern)} modern + {len(valid_original)} shakespeare")
+    print(f"              Test:  {len(test_modern)} parallel pairs")
+
+    # Training dataset: flat, non-parallel
+    train_dataset = StyleDataset(train_modern, train_original, data_config)
+    valid_dataset = StyleDataset(valid_modern, valid_original, data_config)
+
+    # Test dataset: parallel for BLEU evaluation
+    test_eval_dataset = ParallelEvalDataset(test_modern, test_original)
+
+    # Collate functions
+    train_collate = make_train_collate_fn(tokenizer, model_config.max_seq_len)
+    eval_collate = make_eval_collate_fn(tokenizer, model_config.max_seq_len)
+
+    loaders = {
+        "train": DataLoader(
+            train_dataset,
+            batch_size=batch_size,
+            shuffle=True,                # Shuffle is critical — we want modern and
+            num_workers=num_workers,      # Shakespeare sentences interleaved randomly
+            collate_fn=train_collate,     # so each batch has a mix of both styles.
+            pin_memory=True,
+            drop_last=True,              # Drop last incomplete batch for stable
+        ),                               # contrastive loss (needs consistent batch size)
+        "valid": DataLoader(
+            valid_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=num_workers,
+            collate_fn=train_collate,
+            pin_memory=True,
+        ),
+        "test_eval": DataLoader(
+            test_eval_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=num_workers,
+            collate_fn=eval_collate,
+            pin_memory=True,
+        ),
+    }
+
+    return loaders

--- a/code/tst-training-v2/inference.py
+++ b/code/tst-training-v2/inference.py
@@ -1,0 +1,397 @@
+"""
+inference.py — Style transfer inference and evaluation.
+
+How style transfer works at inference:
+══════════════════════════════════════
+
+1. ENCODE: Feed a modern English sentence through the encoder.
+   This produces z_c (content latent) and z_s (style latent).
+   z_c captures WHAT the sentence says (entities, relationships, meaning).
+   z_s captures HOW it says it (modern style).
+
+2. SWAP STYLE: Discard the modern z_s. Replace it with the average
+   Shakespeare z_s computed from the training data. This tells the
+   decoder "keep the same content, but generate in Shakespeare style."
+
+3. DECODE: Feed [z_c; avg_shakespeare_z_s] through the autoregressive
+   decoder. The decoder generates Shakespeare-style text one token at
+   a time, preserving the content from z_c.
+
+4. POST-PROCESS: The nltk tokenization in the training data added extra
+   spaces before punctuation (e.g., "speak'st ."). The decoder may
+   reproduce this pattern. We strip these artifacts.
+
+Evaluation:
+  - BLEU score against ground-truth parallel Shakespeare sentences
+  - Style accuracy (optional: train a simple classifier)
+  - Content preservation (BLEU between input content words and output)
+"""
+
+import os
+import re
+from pathlib import Path
+
+# Redirect HuggingFace cache to project space to avoid home dir quota
+_hf_cache = "/projectnb/scottml/seansal2/.cache/huggingface"
+os.makedirs(_hf_cache, exist_ok=True)
+os.environ.setdefault("HF_HOME", _hf_cache)
+
+import torch
+import torch.nn.functional as F
+from transformers import AutoTokenizer
+
+from config import ModelConfig, TrainConfig, DataConfig
+from model import VAETransformer, load_llama_embeddings
+from data import build_dataloaders, load_sentences
+
+
+# ──────────────────────────────────────────────────────────
+# Post-processing
+# ──────────────────────────────────────────────────────────
+
+def clean_nltk_artifacts(text: str) -> str:
+    """
+    Clean up spacing artifacts from nltk tokenization.
+
+    The .nltktok training data has spaces before punctuation:
+        "I have a mind to strike thee ."
+    LLaMA's BPE may reproduce this pattern. This function normalizes:
+        "I have a mind to strike thee."
+    """
+    # Remove spaces before punctuation
+    text = re.sub(r'\s+([.,!?;:\'\")\]])', r'\1', text)
+    # Remove spaces after opening brackets/quotes
+    text = re.sub(r'([\[(\"\'])\s+', r'\1', text)
+    # Collapse multiple spaces
+    text = re.sub(r'\s+', ' ', text)
+    return text.strip()
+
+
+# ──────────────────────────────────────────────────────────
+# Style transfer
+# ──────────────────────────────────────────────────────────
+
+class StyleTransfer:
+    """
+    Performs style transfer using a trained VAE model.
+
+    Usage:
+        transfer = StyleTransfer.from_checkpoint("checkpoints/final_model.pt")
+        result = transfer.transfer("I have half a mind to hit you.", target_style=1)
+        print(result)  # Shakespeare-style output
+    """
+
+    def __init__(
+        self,
+        model: VAETransformer,
+        tokenizer: AutoTokenizer,
+        avg_style_embs: dict[int, torch.Tensor],
+        model_config: ModelConfig,
+        device: torch.device,
+    ):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.avg_style_embs = avg_style_embs
+        self.config = model_config
+        self.device = device
+        self.model.eval()
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        checkpoint_path: str | Path,
+        device: torch.device | None = None,
+    ) -> "StyleTransfer":
+        """
+        Load a trained model from a checkpoint file.
+
+        The checkpoint contains:
+          - model_state_dict: Trained model weights
+          - avg_style_embs: Average z_s for each style (computed after training)
+          - model_config: Architecture hyperparameters
+        """
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+        print(f"Loading checkpoint from {checkpoint_path}...")
+        ckpt = torch.load(checkpoint_path, map_location=device, weights_only=False)
+
+        model_config = ckpt["model_config"]
+        avg_style_embs = ckpt["avg_style_embs"]
+
+        # Rebuild model
+        embedding_layer = load_llama_embeddings(model_config.llama_model_name)
+        model = VAETransformer(model_config, embedding_layer).to(device)
+        model.load_state_dict(ckpt["model_state_dict"])
+
+        # Tokenizer
+        tokenizer = AutoTokenizer.from_pretrained(model_config.llama_model_name)
+        if tokenizer.pad_token is None:
+            tokenizer.pad_token = tokenizer.eos_token
+
+        print(f"Model loaded. Available styles: {list(avg_style_embs.keys())}")
+        return cls(model, tokenizer, avg_style_embs, model_config, device)
+
+    @torch.no_grad()
+    def transfer(
+        self,
+        text: str,
+        target_style: int,
+        max_len: int = 64,
+        temperature: float = 1.0,
+        top_k: int | None = None,
+    ) -> str:
+        """
+        Transfer the style of a single sentence.
+
+        Args:
+            text:         Input sentence (any style)
+            target_style: Target style label (0=modern, 1=Shakespeare)
+            max_len:      Maximum output length
+            temperature:  Sampling temperature
+            top_k:        Top-k sampling (None=greedy)
+
+        Returns:
+            Style-transferred text
+        """
+        # Tokenize input
+        encoded = self.tokenizer(
+            text,
+            padding=False,
+            truncation=True,
+            max_length=self.config.max_seq_len,
+            return_tensors="pt",
+        )
+        input_ids = encoded["input_ids"].to(self.device)
+        attention_mask = encoded["attention_mask"].to(self.device)
+
+        # Encode → get content latent (keep) and style latent (discard)
+        c_mu, c_log_var, s_mu, s_log_var = self.model.encode(input_ids, attention_mask)
+
+        # Use content MEAN (not sampled) for more deterministic output
+        z_c = c_mu
+
+        # Replace style with target style prototype
+        target_z_s = self.avg_style_embs[target_style].to(self.device)
+        target_z_s = target_z_s.unsqueeze(0)  # (1, style_latent_dim)
+
+        # Concatenate content + target style
+        z = torch.cat([z_c, target_z_s], dim=-1)  # (1, total_latent_dim)
+
+        # Generate
+        generated_ids = self.model.decode_generate(
+            z=z,
+            bos_token_id=self.tokenizer.bos_token_id,
+            eos_token_id=self.tokenizer.eos_token_id,
+            pad_token_id=self.tokenizer.pad_token_id,
+            max_len=max_len,
+            temperature=temperature,
+            top_k=top_k,
+        )
+
+        # Decode tokens back to text
+        output_text = self.tokenizer.decode(
+            generated_ids[0],
+            skip_special_tokens=True,
+        )
+
+        return clean_nltk_artifacts(output_text)
+
+    @torch.no_grad()
+    def transfer_batch(
+        self,
+        texts: list[str],
+        target_style: int,
+        max_len: int = 64,
+        temperature: float = 1.0,
+        top_k: int | None = None,
+    ) -> list[str]:
+        """Transfer style for a batch of sentences."""
+        # Tokenize
+        encoded = self.tokenizer(
+            texts,
+            padding=True,
+            truncation=True,
+            max_length=self.config.max_seq_len,
+            return_tensors="pt",
+        )
+        input_ids = encoded["input_ids"].to(self.device)
+        attention_mask = encoded["attention_mask"].to(self.device)
+
+        # Encode
+        c_mu, c_log_var, s_mu, s_log_var = self.model.encode(input_ids, attention_mask)
+        z_c = c_mu
+
+        # Replace style
+        batch_size = z_c.size(0)
+        target_z_s = self.avg_style_embs[target_style].to(self.device)
+        target_z_s = target_z_s.unsqueeze(0).expand(batch_size, -1)
+
+        z = torch.cat([z_c, target_z_s], dim=-1)
+
+        # Generate
+        generated_ids = self.model.decode_generate(
+            z=z,
+            bos_token_id=self.tokenizer.bos_token_id,
+            eos_token_id=self.tokenizer.eos_token_id,
+            pad_token_id=self.tokenizer.pad_token_id,
+            max_len=max_len,
+            temperature=temperature,
+            top_k=top_k,
+        )
+
+        # Decode
+        results = []
+        for i in range(batch_size):
+            text = self.tokenizer.decode(generated_ids[i], skip_special_tokens=True)
+            results.append(clean_nltk_artifacts(text))
+
+        return results
+
+
+# ──────────────────────────────────────────────────────────
+# BLEU evaluation
+# ──────────────────────────────────────────────────────────
+
+def compute_bleu_scores(
+    transfer: StyleTransfer,
+    test_modern: list[str],
+    test_original: list[str],
+    target_style: int = 1,
+    max_samples: int | None = None,
+    batch_size: int = 32,
+) -> dict:
+    """
+    Evaluate style transfer quality using BLEU against parallel ground truth.
+
+    For each modern sentence:
+      1. Transfer to Shakespeare style using the model
+      2. Compare generated output to the ground-truth parallel Shakespeare sentence
+      3. Compute corpus-level and sentence-level BLEU
+
+    Args:
+        transfer:      StyleTransfer object
+        test_modern:   List of modern English test sentences
+        test_original: List of parallel Shakespeare test sentences (ground truth)
+        target_style:  Target style label (1=Shakespeare)
+        max_samples:   Limit number of samples (None=all)
+        batch_size:    Batch size for generation
+
+    Returns:
+        dict with BLEU scores and sample outputs
+    """
+    try:
+        from nltk.translate.bleu_score import corpus_bleu, sentence_bleu, SmoothingFunction
+    except ImportError:
+        print("nltk not installed. Run: pip install nltk")
+        return {}
+
+    if max_samples is not None:
+        test_modern = test_modern[:max_samples]
+        test_original = test_original[:max_samples]
+
+    # Generate in batches
+    all_generated = []
+    for i in range(0, len(test_modern), batch_size):
+        batch = test_modern[i:i + batch_size]
+        generated = transfer.transfer_batch(batch, target_style=target_style)
+        all_generated.extend(generated)
+        if (i // batch_size) % 10 == 0:
+            print(f"  Generated {len(all_generated)}/{len(test_modern)}...")
+
+    # Compute BLEU
+    # References are lists of lists of tokens (multiple references per sentence)
+    # Hypotheses are lists of tokens
+    references = [[ref.split()] for ref in test_original]
+    hypotheses = [gen.split() for gen in all_generated]
+
+    smoother = SmoothingFunction().method1
+    bleu_4 = corpus_bleu(references, hypotheses, smoothing_function=smoother)
+    bleu_1 = corpus_bleu(
+        references, hypotheses,
+        weights=(1.0, 0, 0, 0),
+        smoothing_function=smoother,
+    )
+
+    # Sample outputs for inspection
+    samples = []
+    for i in range(min(10, len(test_modern))):
+        samples.append({
+            "input": test_modern[i],
+            "generated": all_generated[i],
+            "reference": test_original[i],
+        })
+
+    results = {
+        "bleu_1": bleu_1,
+        "bleu_4": bleu_4,
+        "num_samples": len(test_modern),
+        "samples": samples,
+    }
+
+    print(f"\n  BLEU-1: {bleu_1:.4f}")
+    print(f"  BLEU-4: {bleu_4:.4f}")
+    print(f"\n  Sample transfers:")
+    for s in samples[:5]:
+        print(f"    Input:     {s['input']}")
+        print(f"    Generated: {s['generated']}")
+        print(f"    Reference: {s['reference']}")
+        print()
+
+    return results
+
+
+# ──────────────────────────────────────────────────────────
+# Quick demo
+# ──────────────────────────────────────────────────────────
+
+def demo(checkpoint_path: str = "checkpoints/final_model.pt"):
+    """
+    Quick demo: transfer a few example sentences.
+    """
+    transfer = StyleTransfer.from_checkpoint(checkpoint_path)
+
+    modern_sentences = [
+        "I have half a mind to hit you before you speak again.",
+        "You are an honest man.",
+        "I'm going to make you a rich man.",
+        "Have you given up so quickly on Rosaline, whom you loved so much?",
+        "Holy Saint Francis, this is a drastic change!",
+    ]
+
+    print("\n" + "=" * 60)
+    print("STYLE TRANSFER DEMO: Modern → Shakespeare")
+    print("=" * 60)
+
+    for sent in modern_sentences:
+        result = transfer.transfer(sent, target_style=1)  # 1 = Shakespeare
+        print(f"\n  Modern:      {sent}")
+        print(f"  Shakespeare: {result}")
+
+
+def evaluate(checkpoint_path: str = "checkpoints/final_model.pt"):
+    """
+    Full evaluation: BLEU scores on the test set.
+    """
+    data_config = DataConfig()
+    transfer = StyleTransfer.from_checkpoint(checkpoint_path)
+
+    test_modern = load_sentences(data_config.get_path(data_config.test_modern))
+    test_original = load_sentences(data_config.get_path(data_config.test_original))
+
+    print("\n" + "=" * 60)
+    print("EVALUATION: Modern → Shakespeare (BLEU on test set)")
+    print("=" * 60)
+
+    results = compute_bleu_scores(transfer, test_modern, test_original)
+    return results
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1 and sys.argv[1] == "eval":
+        ckpt = sys.argv[2] if len(sys.argv) > 2 else "checkpoints/final_model.pt"
+        evaluate(ckpt)
+    else:
+        ckpt = sys.argv[1] if len(sys.argv) > 1 else "checkpoints/final_model.pt"
+        demo(ckpt)

--- a/code/tst-training-v2/losses.py
+++ b/code/tst-training-v2/losses.py
@@ -1,0 +1,364 @@
+"""
+losses.py — Loss functions for the Text Style Transfer VAE.
+
+Total loss = L_recon + β(step)·(KL_c + KL_s) + γ·HSIC(z_c, z_s) + λ·Contrastive(z_s)
+
+Each component explained:
+═════════════════════════
+
+1. RECONSTRUCTION LOSS (L_recon)
+   Cross-entropy between predicted next-token logits and ground truth.
+   This is the standard language modeling loss — it teaches the decoder
+   to produce coherent text. Padding tokens are ignored.
+
+2. KL DIVERGENCE (KL_c + KL_s)
+   Pushes the learned posterior q(z|x) toward the prior N(0, I).
+   Without this, the encoder could learn a delta function (zero variance)
+   at a different location for each input — making the latent space
+   non-continuous and useless for generation.
+
+   β is annealed via a sigmoid schedule to prevent posterior collapse:
+   early in training β≈0, so the model focuses on reconstruction;
+   β gradually increases to 1.0, adding the KL regularization.
+
+3. HSIC (Hilbert-Schmidt Independence Criterion)
+   Measures statistical dependence between z_c and z_s using kernel
+   methods. Minimizing HSIC pushes the content and style latent spaces
+   toward independence. This replaces John et al.'s adversarial losses.
+
+   Advantage over adversarial: single differentiable loss, no min-max
+   game, no separate optimizer groups, more stable training.
+
+   Disadvantage: only measures kernel-based dependence, not arbitrary
+   nonlinear relationships. In practice, this is sufficient for the
+   Shakespeare/modern distinction.
+
+4. CONTRASTIVE STYLE LOSS
+   InfoNCE-style loss on z_s. For each sentence, all other sentences
+   with the SAME style label are positives, and sentences with different
+   style labels are negatives. This clusters same-style z_s vectors
+   together and separates different-style vectors.
+
+   Replaces John et al.'s multitask style classifier. The contrastive
+   formulation is more flexible and doesn't require a fixed classification
+   head.
+
+What's NOT included (compared to John et al.):
+   - Content multitask loss (BoW prediction from z_c). Could be added
+     later if content preservation is poor.
+   - Adversarial losses. Replaced by HSIC.
+
+Kept from professor's transformer_vae_original.ipynb:
+   - All four loss functions (reconstruction, KL+annealing, HSIC, contrastive)
+   - Fixed: stray 'b' character removed, consistent naming
+"""
+
+import math
+import torch
+import torch.nn.functional as F
+
+
+# ──────────────────────────────────────────────────────────
+# 1. Reconstruction loss
+# ──────────────────────────────────────────────────────────
+
+def reconstruction_loss(
+    logits: torch.Tensor,
+    targets: torch.Tensor,
+    pad_token_id: int,
+) -> torch.Tensor:
+    """
+    Token-level cross-entropy loss, ignoring padding positions.
+
+    Args:
+        logits:       (batch, seq_len, vocab_size) — predicted next-token logits
+        targets:      (batch, seq_len)             — ground truth token IDs
+        pad_token_id: Token ID used for padding (excluded from loss)
+
+    Returns:
+        Scalar loss (mean over non-padding tokens)
+    """
+    vocab_size = logits.size(-1)
+    loss = F.cross_entropy(
+        logits.reshape(-1, vocab_size),
+        targets.reshape(-1),
+        ignore_index=pad_token_id,
+    )
+    return loss
+
+
+# ──────────────────────────────────────────────────────────
+# 2. KL divergence with sigmoid annealing
+# ──────────────────────────────────────────────────────────
+
+def kl_divergence(mu: torch.Tensor, log_var: torch.Tensor) -> torch.Tensor:
+    """
+    KL(q(z|x) || N(0, I)) for a diagonal Gaussian posterior.
+
+    Derivation:
+        KL = -0.5 * Σ (1 + log(σ²) - μ² - σ²)
+           = -0.5 * Σ (1 + log_var - mu² - exp(log_var))
+
+    Averaged over the batch.
+
+    Args:
+        mu:      (batch, latent_dim) — posterior mean
+        log_var: (batch, latent_dim) — posterior log-variance
+
+    Returns:
+        Scalar KL divergence
+    """
+    return -0.5 * torch.mean(
+        torch.sum(1 + log_var - mu.pow(2) - log_var.exp(), dim=-1)
+    )
+
+
+def kl_anneal_factor(step: int, midpoint: int = 5000, steepness: float = 0.002) -> float:
+    """
+    Sigmoid KL annealing schedule.
+
+    Returns a weight β ∈ [0, 1] that multiplies the KL loss.
+
+    Early in training (step << midpoint): β ≈ 0, model focuses on reconstruction.
+    At step = midpoint: β = 0.5.
+    Late in training (step >> midpoint): β ≈ 1.0, full KL regularization.
+
+    This prevents posterior collapse — the phenomenon where the decoder
+    learns to ignore z because the KL penalty pushes z to pure noise
+    before the decoder has learned to use it.
+
+    The sigmoid shape is:
+        β(step) = σ(steepness · (step - midpoint))
+                = 1 / (1 + exp(-steepness · (step - midpoint)))
+
+    Args:
+        step:      Current global training step
+        midpoint:  Step where β=0.5 (inflection point)
+        steepness: Controls how sharply β transitions from 0 to 1
+
+    Returns:
+        Float in [0, 1]
+    """
+    return 1.0 / (1.0 + math.exp(-steepness * (step - midpoint)))
+
+
+# ──────────────────────────────────────────────────────────
+# 3. HSIC (Hilbert-Schmidt Independence Criterion)
+# ──────────────────────────────────────────────────────────
+
+def rbf_kernel(x: torch.Tensor, sigma: float | None = None) -> torch.Tensor:
+    """
+    Radial Basis Function (Gaussian) kernel matrix.
+
+    K(x_i, x_j) = exp(-||x_i - x_j||² / (2σ²))
+
+    If sigma is None, uses the median heuristic: σ = sqrt(median_distance / 2).
+    This adaptive bandwidth ensures the kernel is sensitive to the actual
+    scale of the data.
+
+    Args:
+        x:     (B, D) — batch of vectors
+        sigma: Kernel bandwidth (None = median heuristic)
+
+    Returns:
+        K: (B, B) — kernel matrix
+    """
+    # Pairwise squared Euclidean distances
+    x_norm = (x ** 2).sum(dim=1).view(-1, 1)      # (B, 1)
+    dist = x_norm + x_norm.t() - 2.0 * (x @ x.t())  # (B, B)
+    dist = dist.clamp(min=0.0)  # Numerical stability
+
+    if sigma is None:
+        # Median heuristic: exclude diagonal (distance to self = 0)
+        mask = ~torch.eye(dist.size(0), dtype=torch.bool, device=x.device)
+        median_dist = torch.median(dist[mask])
+        sigma = torch.sqrt(0.5 * median_dist).clamp(min=1e-5)
+
+    K = torch.exp(-dist / (2.0 * sigma ** 2 + 1e-8))
+    return K
+
+
+def hsic_loss(
+    z_content: torch.Tensor,
+    z_style: torch.Tensor,
+) -> torch.Tensor:
+    """
+    HSIC (Hilbert-Schmidt Independence Criterion) between z_c and z_s.
+
+    HSIC is zero if and only if z_c and z_s are independent (in the RKHS
+    induced by the chosen kernel). It's always non-negative, so minimizing
+    it pushes the two spaces toward independence.
+
+    Formula (biased estimator):
+        HSIC = (1/(B-1)²) · trace(K·H·L·H)
+    where:
+        K = kernel matrix of z_content
+        L = kernel matrix of z_style
+        H = centering matrix = I - (1/B)·11ᵀ
+
+    This replaces John et al.'s adversarial losses (style discriminator on
+    content space + content discriminator on style space). Same goal
+    (disentanglement), simpler optimization.
+
+    Args:
+        z_content: (batch, content_latent_dim) — sampled content vectors
+        z_style:   (batch, style_latent_dim)   — sampled style vectors
+
+    Returns:
+        Scalar HSIC value (non-negative)
+    """
+    B = z_content.size(0)
+    if B < 2:
+        return torch.tensor(0.0, device=z_content.device)
+
+    K = rbf_kernel(z_content)
+    L = rbf_kernel(z_style)
+
+    # Centering matrix H = I - (1/B)·11ᵀ
+    H = torch.eye(B, device=z_content.device) - (1.0 / B) * torch.ones(B, B, device=z_content.device)
+
+    # HSIC = (1/(B-1)²) · trace(K·H·L·H)
+    hsic_val = torch.trace(K @ H @ L @ H) / ((B - 1) ** 2)
+
+    return hsic_val
+
+
+# ──────────────────────────────────────────────────────────
+# 4. Contrastive style loss
+# ──────────────────────────────────────────────────────────
+
+def contrastive_style_loss(
+    z_style: torch.Tensor,
+    doc_ids: torch.Tensor,
+    temperature: float = 0.1,
+) -> torch.Tensor:
+    """
+    InfoNCE-style contrastive loss on the style latent space.
+
+    For each sentence i in the batch:
+      - Positives: all other sentences j where doc_ids[j] == doc_ids[i]
+      - Negatives: all sentences j where doc_ids[j] != doc_ids[i]
+
+    The loss encourages:
+      - Same-style z_s vectors to have high cosine similarity
+      - Different-style z_s vectors to have low cosine similarity
+
+    This clusters Shakespeare z_s vectors together and modern z_s vectors
+    together, creating two distinct regions in the style latent space.
+    At inference, you can swap between these regions to transfer style.
+
+    Lower temperature = sharper similarity distinctions (harder to satisfy).
+    temperature=0.1 is standard for contrastive learning.
+
+    Args:
+        z_style:     (batch, style_latent_dim) — style latent vectors
+        doc_ids:     (batch,) — style labels (0=modern, 1=Shakespeare)
+        temperature: Sharpness of similarity (lower = sharper)
+
+    Returns:
+        Scalar loss (negative of mean log-probability of positives)
+    """
+    # L2-normalize style vectors for cosine similarity
+    z = F.normalize(z_style, dim=-1)
+    sim = z @ z.t()  # (B, B) cosine similarity matrix
+
+    # Mask out self-similarity (diagonal)
+    B = z.size(0)
+    self_mask = torch.eye(B, device=z.device).bool()
+    sim.masked_fill_(self_mask, -1e9)
+
+    # Build positive mask: same doc_id, different index
+    doc_ids_col = doc_ids.view(-1, 1)
+    pos_mask = (doc_ids_col == doc_ids_col.t()) & (~self_mask)  # (B, B)
+
+    # Scaled logits → log-softmax over all non-self entries
+    logits = sim / temperature
+    log_probs = F.log_softmax(logits, dim=1)
+
+    # Average log-probability over positive pairs
+    # Each row: sum of log_probs at positive positions / number of positives
+    num_positives = pos_mask.float().sum(dim=1).clamp(min=1e-8)
+    pos_log_probs = (log_probs * pos_mask.float()).sum(dim=1) / num_positives
+
+    return -pos_log_probs.mean()
+
+
+# ──────────────────────────────────────────────────────────
+# Combined loss
+# ──────────────────────────────────────────────────────────
+
+def compute_total_loss(
+    logits: torch.Tensor,
+    tgt_output: torch.Tensor,
+    pad_token_id: int,
+    c_mu: torch.Tensor,
+    c_log_var: torch.Tensor,
+    s_mu: torch.Tensor,
+    s_log_var: torch.Tensor,
+    z_c: torch.Tensor,
+    z_s: torch.Tensor,
+    doc_ids: torch.Tensor,
+    global_step: int,
+    gamma_hsic: float = 1.0,
+    lambda_contrast: float = 1.0,
+    contrastive_temperature: float = 0.1,
+    kl_anneal_midpoint: int = 5000,
+    kl_anneal_steepness: float = 0.002,
+) -> tuple[torch.Tensor, dict]:
+    """
+    Compute the total VAE loss with all components.
+
+    L = L_recon + β(step)·(KL_c + KL_s) + γ·HSIC(z_c, z_s) + λ·Contrastive(z_s)
+
+    Args:
+        logits:      (batch, seq_len-1, vocab_size) — decoder output
+        tgt_output:  (batch, seq_len-1) — ground truth next tokens
+        pad_token_id: Padding token ID
+        c_mu, c_log_var: Content latent distribution parameters
+        s_mu, s_log_var: Style latent distribution parameters
+        z_c, z_s:    Sampled latent vectors
+        doc_ids:     Style labels
+        global_step: Current training step (for KL annealing)
+        gamma_hsic:  Weight for HSIC loss
+        lambda_contrast: Weight for contrastive loss
+        contrastive_temperature: Temperature for contrastive loss
+        kl_anneal_midpoint: Step where β=0.5
+        kl_anneal_steepness: Sigmoid sharpness for annealing
+
+    Returns:
+        total_loss: Scalar tensor
+        metrics:    Dict of individual loss values (for logging)
+    """
+    # 1. Reconstruction
+    recon = reconstruction_loss(logits, tgt_output, pad_token_id)
+
+    # 2. KL divergence (content + style) with annealing
+    kl_c = kl_divergence(c_mu, c_log_var)
+    kl_s = kl_divergence(s_mu, s_log_var)
+    kl_total = kl_c + kl_s
+    beta = kl_anneal_factor(global_step, kl_anneal_midpoint, kl_anneal_steepness)
+    kl_term = beta * kl_total
+
+    # 3. HSIC independence loss
+    hsic_term = gamma_hsic * hsic_loss(z_c, z_s)
+
+    # 4. Contrastive style loss
+    contrast_term = lambda_contrast * contrastive_style_loss(
+        z_s, doc_ids, contrastive_temperature
+    )
+
+    # Total
+    total = recon + kl_term + hsic_term + contrast_term
+
+    metrics = {
+        "loss": total.item(),
+        "recon": recon.item(),
+        "kl_c": kl_c.item(),
+        "kl_s": kl_s.item(),
+        "kl_total": kl_total.item(),
+        "beta": beta,
+        "hsic": hsic_term.item(),
+        "contrast": contrast_term.item(),
+    }
+
+    return total, metrics

--- a/code/tst-training-v2/model.py
+++ b/code/tst-training-v2/model.py
@@ -1,0 +1,562 @@
+"""
+model.py — VAE Transformer for Text Style Transfer.
+
+Architecture decisions and their rationale:
+═══════════════════════════════════════════
+
+1. FROZEN LLAMA EMBEDDINGS + PROJECTION
+   LLaMA 3.1 8B's embedding table maps 128K BPE tokens to 4096-dim vectors.
+   These embeddings encode rich semantic relationships learned from massive
+   pretraining data — far better than training embeddings from scratch on
+   ~37K Shakespeare sentences. We freeze them (no gradients) to save memory
+   and prevent catastrophic forgetting.
+
+   But 4096 is too wide for our transformer layers (would need ~20GB+ for
+   6-layer transformers). So we add a learned projection: Linear(4096→512)
+   + LayerNorm. This compresses the pretrained representations into a
+   working dimension our transformer can handle efficiently.
+
+2. TRANSFORMER ENCODER → MASKED MEAN POOL → LATENT SPACE
+   The encoder processes the projected embeddings through self-attention
+   layers, then collapses the sequence dimension via masked mean pooling
+   (ignoring padding tokens). This produces a single vector per sentence
+   that gets split into content μ/σ² and style μ/σ² via separate linear
+   projections.
+
+   Why mean pool instead of [CLS] token? Mean pooling is more stable for
+   VAEs because it averages information across all positions, while [CLS]
+   relies on a single position learning to aggregate everything.
+
+3. NO CROSS-ATTENTION IN DECODER (CRITICAL)
+   This is the most important architectural choice. A standard Transformer
+   decoder cross-attends to encoder memory, meaning it can read the full
+   encoded input sequence at every decoding step. For a VAE, this is
+   catastrophic: the decoder bypasses the latent bottleneck entirely by
+   just copying from encoder memory. The latent z becomes noise, HSIC is
+   trivially low, and style transfer fails.
+
+   Instead, our decoder uses ONLY causal self-attention. Its inputs are:
+     - Shifted target token embeddings (teacher forcing during training)
+     - The latent vector z projected back to d_model and ADDED to each position
+     - Learned positional encodings
+
+   All global information (content + style) must flow through the
+   160-dimensional bottleneck (128 content + 32 style). This forces
+   meaningful latent representations.
+
+4. AUTOREGRESSIVE DECODING
+   During training: teacher forcing — the decoder sees the ground-truth
+   previous tokens shifted right, and predicts the next token at each
+   position. Loss is computed on all positions simultaneously.
+
+   During inference: greedy or top-k sampling — generate one token at a
+   time, feeding each generated token back as input for the next step.
+
+5. OUTPUT PROJECTION WITH WEIGHT TYING
+   The output head projects from d_model back to vocab_size. We tie the
+   output projection weights to the input embedding weights (through the
+   projection layer). This is parameter-efficient and encourages the model
+   to produce outputs in the same semantic space as its inputs.
+
+   Specifically: output_logits = (decoder_output @ projection.T) @ embedding.T
+   This means we go d_model → 4096 → 128256 (vocab logits) by reusing
+   the projection and embedding matrices. No extra parameters needed for
+   the output head.
+"""
+
+import json
+import math
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from safetensors import safe_open
+from huggingface_hub import hf_hub_download
+
+from config import ModelConfig
+
+
+# ──────────────────────────────────────────────────────────
+# Embedding loading (from vae_style_transfer_starter-3.4.ipynb)
+# ──────────────────────────────────────────────────────────
+
+def load_llama_embeddings(model_name: str) -> nn.Embedding:
+    """
+    Load ONLY the embedding layer from LLaMA 3.1 8B without loading the
+    full 8B parameter model.
+
+    Uses safetensors memory mapping (safe_open) to extract just the
+    embedding tensor from the correct model shard. This uses ~1GB of RAM
+    instead of ~16GB for the full model.
+
+    From notebook 3 (vae_style_transfer_starter), Option B simplified.
+    """
+    # 1. Download the safetensors index to find which shard has embeddings
+    index_path = hf_hub_download(model_name, "model.safetensors.index.json")
+    with open(index_path) as f:
+        index = json.load(f)
+
+    # 2. Locate the shard containing the embedding weights
+    embed_key = "model.embed_tokens.weight"
+    shard_file = index["weight_map"][embed_key]
+    shard_path = hf_hub_download(model_name, shard_file)
+
+    # 3. Memory-map the shard and extract ONLY the embedding tensor
+    # safe_open maps the file without loading the entire shard into RAM
+    with safe_open(shard_path, framework="pt", device="cpu") as f:
+        embed_weight = f.get_tensor(embed_key)  # (vocab_size, 4096)
+
+    vocab_size, embed_dim = embed_weight.shape
+    print(f"Loaded LLaMA embeddings: vocab_size={vocab_size}, embed_dim={embed_dim}")
+    print(f"  dtype={embed_weight.dtype}, size={embed_weight.nelement() * embed_weight.element_size() / 1e9:.2f} GB")
+
+    # Keep native dtype (bfloat16) to save memory — the projection layer
+    # will cast to float32 as needed during the forward pass.
+    embedding_layer = nn.Embedding(vocab_size, embed_dim, _weight=embed_weight)
+    return embedding_layer
+
+
+# ──────────────────────────────────────────────────────────
+# Positional encoding
+# ──────────────────────────────────────────────────────────
+
+class SinusoidalPositionalEncoding(nn.Module):
+    """
+    Standard sinusoidal positional encoding from "Attention Is All You Need".
+
+    Why sinusoidal instead of learned? With max_seq_len=128 and d_model=512,
+    learned positional embeddings would add 65K parameters — trivial. But
+    sinusoidal encodings generalize better to unseen sequence lengths and
+    are a well-understood baseline. Either works fine here.
+    """
+
+    def __init__(self, d_model: int, max_len: int = 512, dropout: float = 0.1):
+        super().__init__()
+        self.dropout = nn.Dropout(dropout)
+
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0)  # (1, max_len, d_model)
+
+        # Register as buffer (not a parameter — no gradients, but moves with .to())
+        self.register_buffer("pe", pe)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """x: (batch, seq_len, d_model)"""
+        x = x + self.pe[:, :x.size(1), :]
+        return self.dropout(x)
+
+
+# ──────────────────────────────────────────────────────────
+# Main model
+# ──────────────────────────────────────────────────────────
+
+class VAETransformer(nn.Module):
+    """
+    VAE with Transformer encoder and autoregressive Transformer decoder
+    for text style transfer.
+
+    Forward pass (training):
+        input_ids, attention_mask
+        → embed(input_ids)                               # (B, S, 4096)
+        → project(embed)                                  # (B, S, 512)
+        → encoder(projected)                              # (B, S, 512)
+        → masked_mean_pool → content μ/σ², style μ/σ²    # each (B, latent_dim)
+        → reparameterize → z_c, z_s                       # (B, 128), (B, 32)
+        → concat [z_c; z_s] → project to d_model          # (B, 512)
+        → decoder(shifted_targets + z_broadcast)           # (B, S-1, 512)
+        → output_proj → logits                            # (B, S-1, vocab_size)
+
+    The decoder does NOT cross-attend to encoder memory. All information
+    flows through the 160-dim latent bottleneck.
+    """
+
+    def __init__(self, config: ModelConfig, embedding_layer: nn.Embedding):
+        super().__init__()
+        self.config = config
+
+        # ─── Frozen pretrained embeddings ───
+        self.embedding = embedding_layer
+        self.embedding.weight.requires_grad = False
+        actual_vocab_size = embedding_layer.weight.shape[0]
+        actual_embed_dim = embedding_layer.weight.shape[1]
+
+        # ─── Projection: 4096 → d_model ───
+        # This is a learned linear map that compresses LLaMA's rich 4096-dim
+        # embeddings into our working dimension. LayerNorm stabilizes training.
+        self.input_projection = nn.Sequential(
+            nn.Linear(actual_embed_dim, config.d_model),
+            nn.LayerNorm(config.d_model),
+        )
+
+        # ─── Positional encoding ───
+        self.pos_encoder = SinusoidalPositionalEncoding(
+            config.d_model, max_len=config.max_seq_len, dropout=config.dropout
+        )
+
+        # ─── Transformer encoder ───
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=config.d_model,
+            nhead=config.n_heads,
+            dim_feedforward=config.dim_feedforward,
+            dropout=config.dropout,
+            batch_first=True,           # (batch, seq, d_model) convention
+        )
+        self.encoder = nn.TransformerEncoder(
+            encoder_layer, num_layers=config.n_encoder_layers
+        )
+
+        # ─── Latent projections ───
+        # From pooled encoder output (d_model) to content and style latent spaces.
+        # Separate μ and log_var heads for each space.
+        self.content_mu = nn.Linear(config.d_model, config.content_latent_dim)
+        self.content_log_var = nn.Linear(config.d_model, config.content_latent_dim)
+        self.style_mu = nn.Linear(config.d_model, config.style_latent_dim)
+        self.style_log_var = nn.Linear(config.d_model, config.style_latent_dim)
+
+        # ─── Latent → decoder space ───
+        # Maps the concatenated [z_c; z_s] back to d_model for the decoder.
+        self.latent_to_d_model = nn.Linear(config.total_latent_dim, config.d_model)
+
+        # ─── Transformer decoder (self-attention ONLY, no cross-attention) ───
+        # We use TransformerEncoder with causal masking, NOT TransformerDecoder.
+        # TransformerDecoder expects cross-attention memory, which we don't want.
+        # TransformerEncoder with a causal mask gives us the same autoregressive
+        # behavior without any cross-attention to encoder outputs.
+        decoder_layer = nn.TransformerEncoderLayer(
+            d_model=config.d_model,
+            nhead=config.n_heads,
+            dim_feedforward=config.dim_feedforward,
+            dropout=config.dropout,
+            batch_first=True,
+        )
+        self.decoder = nn.TransformerEncoder(
+            decoder_layer, num_layers=config.n_decoder_layers
+        )
+
+        # ─── Output projection (weight-tied) ───
+        # Instead of a massive Linear(512, 128256), we reverse the projection:
+        # d_model → 4096 via input_projection.T, then 4096 → vocab via embedding.T.
+        # This reuses existing weights and encourages semantic consistency.
+        self.output_unproject = nn.Linear(config.d_model, actual_embed_dim, bias=False)
+        # The final vocab projection uses the frozen embedding weights (tied).
+        # We don't create a separate parameter — see _compute_logits().
+
+    def _compute_logits(self, decoder_output: torch.Tensor) -> torch.Tensor:
+        """
+        Project decoder output to vocabulary logits using weight tying.
+
+        decoder_output: (batch, seq_len, d_model)
+        returns:        (batch, seq_len, vocab_size)
+
+        Path: d_model → 4096 → vocab_size
+        The second projection reuses the frozen embedding weights.
+        """
+        # (batch, seq_len, d_model) → (batch, seq_len, 4096)
+        h = self.output_unproject(decoder_output)
+        # Cast to match frozen LLaMA embedding dtype (bfloat16) before matmul
+        h = h.to(self.embedding.weight.dtype)
+        # (batch, seq_len, 4096) @ (4096, vocab_size) → (batch, seq_len, vocab_size)
+        logits = F.linear(h, self.embedding.weight)
+        return logits
+
+    @staticmethod
+    def _build_causal_mask(seq_len: int, device: torch.device) -> torch.Tensor:
+        """
+        Build an upper-triangular causal mask for autoregressive decoding.
+
+        Returns a (seq_len, seq_len) boolean tensor where True = BLOCKED.
+        Position i can attend to positions 0..i but not i+1..seq_len-1.
+        """
+        return torch.triu(
+            torch.ones(seq_len, seq_len, device=device, dtype=torch.bool),
+            diagonal=1,
+        )
+
+    def encode(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> tuple:
+        """
+        Encode input tokens to latent content and style distributions.
+
+        Args:
+            input_ids:      (batch, seq_len) — token IDs from LLaMA tokenizer
+            attention_mask: (batch, seq_len) — 1=real token, 0=padding
+
+        Returns:
+            c_mu, c_log_var: (batch, content_latent_dim) — content distribution
+            s_mu, s_log_var: (batch, style_latent_dim)   — style distribution
+        """
+        # Step 1: Embed tokens with frozen LLaMA embeddings
+        # Cast to float32 for the projection layer (embeddings may be bfloat16)
+        embeds = self.embedding(input_ids).float()   # (B, S, 4096)
+
+        # Step 2: Project down to working dimension
+        projected = self.input_projection(embeds)     # (B, S, d_model)
+
+        # Step 3: Add positional encoding
+        projected = self.pos_encoder(projected)
+
+        # Step 4: Transformer encoder
+        # src_key_padding_mask: True = IGNORE this position (PyTorch convention)
+        src_key_padding_mask = (attention_mask == 0)
+        memory = self.encoder(
+            projected,
+            src_key_padding_mask=src_key_padding_mask,
+        )  # (B, S, d_model)
+
+        # Step 5: Masked mean pooling → single vector per sentence
+        # Expand mask to match memory dimensions, then average over non-padding
+        mask_f = attention_mask.unsqueeze(-1).float()   # (B, S, 1)
+        pooled = (memory * mask_f).sum(dim=1) / mask_f.sum(dim=1).clamp(min=1.0)
+        # pooled: (B, d_model)
+
+        # Step 6: Project to latent distributions
+        c_mu = self.content_mu(pooled)
+        c_log_var = self.content_log_var(pooled)
+        s_mu = self.style_mu(pooled)
+        s_log_var = self.style_log_var(pooled)
+
+        return c_mu, c_log_var, s_mu, s_log_var
+
+    @staticmethod
+    def reparameterize(mu: torch.Tensor, log_var: torch.Tensor) -> torch.Tensor:
+        """
+        Reparameterization trick: sample z = μ + σ · ε, where ε ~ N(0, I).
+
+        This allows gradients to flow through the sampling operation.
+        During training, this adds stochasticity; at inference, you can
+        just use z = μ (set log_var contribution to 0 or skip this).
+        """
+        std = torch.exp(0.5 * log_var)
+        eps = torch.randn_like(std)
+        return mu + std * eps
+
+    def decode_train(
+        self,
+        z: torch.Tensor,
+        target_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Teacher-forced autoregressive decoding for training.
+
+        The decoder sees shifted ground-truth tokens as input and predicts
+        the next token at each position. The latent vector z is broadcast
+        across all positions and added to the token embeddings.
+
+        Args:
+            z:              (batch, total_latent_dim) — sampled latent vector
+            target_ids:     (batch, seq_len) — full target token IDs [BOS, t1, ..., tN]
+            attention_mask: (batch, seq_len) — attention mask for target
+
+        Returns:
+            logits:     (batch, seq_len-1, vocab_size) — predicted next-token logits
+            tgt_output: (batch, seq_len-1)             — ground truth next tokens
+        """
+        # Teacher forcing: input is [BOS, t1, ..., t_{N-1}], target is [t1, ..., tN]
+        tgt_input = target_ids[:, :-1]       # (B, S-1)
+        tgt_output = target_ids[:, 1:]       # (B, S-1)
+        tgt_mask_input = attention_mask[:, :-1]
+
+        # Embed target tokens and project
+        tgt_embeds = self.embedding(tgt_input).float()   # (B, S-1, 4096)
+        tgt_projected = self.input_projection(tgt_embeds)  # (B, S-1, d_model)
+
+        # Add positional encoding
+        tgt_projected = self.pos_encoder(tgt_projected)
+
+        # Broadcast latent z across all positions and add
+        # This is how global information (content + style) reaches the decoder
+        z_projected = self.latent_to_d_model(z)           # (B, d_model)
+        z_broadcast = z_projected.unsqueeze(1)             # (B, 1, d_model)
+        decoder_input = tgt_projected + z_broadcast        # (B, S-1, d_model)
+
+        # Build causal mask (upper triangular, True = blocked)
+        seq_len = tgt_input.size(1)
+        causal_mask = self._build_causal_mask(seq_len, tgt_input.device)
+
+        # Padding mask for decoder self-attention
+        tgt_key_padding_mask = (tgt_mask_input == 0)
+
+        # Run decoder (self-attention only, no cross-attention)
+        decoder_output = self.decoder(
+            decoder_input,
+            mask=causal_mask,
+            src_key_padding_mask=tgt_key_padding_mask,
+        )  # (B, S-1, d_model)
+
+        # Project to vocab logits
+        logits = self._compute_logits(decoder_output)   # (B, S-1, vocab_size)
+
+        return logits, tgt_output
+
+    @torch.no_grad()
+    def decode_generate(
+        self,
+        z: torch.Tensor,
+        bos_token_id: int,
+        eos_token_id: int,
+        pad_token_id: int,
+        max_len: int = 64,
+        temperature: float = 1.0,
+        top_k: int | None = None,
+    ) -> torch.Tensor:
+        """
+        Autoregressive generation for inference.
+
+        Starting from BOS, generate tokens one at a time by feeding each
+        generated token back as input for the next step. Stops when EOS
+        is generated or max_len is reached.
+
+        Args:
+            z:            (batch, total_latent_dim) — latent vector
+            bos_token_id: Token ID for beginning-of-sequence
+            eos_token_id: Token ID for end-of-sequence
+            pad_token_id: Token ID for padding
+            max_len:      Maximum sequence length to generate
+            temperature:  Sampling temperature (1.0=neutral, <1=sharper, >1=flatter)
+            top_k:        If set, sample from top-k tokens instead of greedy
+
+        Returns:
+            generated: (batch, generated_len) — token IDs including BOS
+        """
+        device = z.device
+        batch_size = z.size(0)
+
+        # Project latent to decoder space
+        z_projected = self.latent_to_d_model(z)           # (B, d_model)
+        z_broadcast = z_projected.unsqueeze(1)             # (B, 1, d_model)
+
+        # Start with BOS token for each sequence
+        cur_tokens = torch.full(
+            (batch_size, 1), bos_token_id, dtype=torch.long, device=device
+        )
+        finished = torch.zeros(batch_size, dtype=torch.bool, device=device)
+
+        for _ in range(max_len):
+            # Embed all tokens generated so far
+            tok_embeds = self.embedding(cur_tokens).float()
+            tok_projected = self.input_projection(tok_embeds)
+            tok_projected = self.pos_encoder(tok_projected)
+
+            # Add latent bias
+            decoder_input = tok_projected + z_broadcast
+
+            # Causal mask
+            seq_len = cur_tokens.size(1)
+            causal_mask = self._build_causal_mask(seq_len, device)
+            pad_mask = (cur_tokens == pad_token_id)
+
+            # Decode
+            decoder_output = self.decoder(
+                decoder_input,
+                mask=causal_mask,
+                src_key_padding_mask=pad_mask,
+            )
+
+            # Get logits for the last position only
+            logits = self._compute_logits(decoder_output[:, -1:, :])  # (B, 1, V)
+            logits = logits.squeeze(1) / temperature                    # (B, V)
+
+            if top_k is not None:
+                # Top-k sampling
+                values, indices = torch.topk(logits, top_k, dim=-1)
+                probs = F.softmax(values, dim=-1)
+                sampled = indices.gather(-1, torch.multinomial(probs, 1))
+                next_tokens = sampled
+            else:
+                # Greedy decoding
+                next_tokens = torch.argmax(logits, dim=-1, keepdim=True)
+
+            # Mark finished sequences
+            finished = finished | (next_tokens.squeeze(-1) == eos_token_id)
+
+            # Append token
+            cur_tokens = torch.cat([cur_tokens, next_tokens], dim=1)
+
+            if finished.all():
+                break
+
+        return cur_tokens
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+    ) -> dict:
+        """
+        Full forward pass for training.
+
+        For non-parallel training, target_ids = input_ids (autoencoder).
+        The model encodes the input, samples from the latent space, and
+        tries to reconstruct the same input via teacher-forced decoding.
+
+        Args:
+            input_ids:      (batch, seq_len) — token IDs
+            attention_mask: (batch, seq_len) — 1=real, 0=pad
+
+        Returns dict with:
+            logits:     (batch, seq_len-1, vocab_size) — next-token predictions
+            tgt_output: (batch, seq_len-1)             — ground truth next tokens
+            c_mu, c_log_var: (batch, content_latent_dim)
+            s_mu, s_log_var: (batch, style_latent_dim)
+            z_c, z_s:        (batch, *_latent_dim) — sampled latent vectors
+        """
+        # Encode
+        c_mu, c_log_var, s_mu, s_log_var = self.encode(input_ids, attention_mask)
+
+        # Reparameterize
+        z_c = self.reparameterize(c_mu, c_log_var)
+        z_s = self.reparameterize(s_mu, s_log_var)
+
+        # Concatenate content + style for decoder
+        z = torch.cat([z_c, z_s], dim=-1)  # (B, total_latent_dim)
+
+        # Decode (teacher forcing: target = input for autoencoder)
+        logits, tgt_output = self.decode_train(z, input_ids, attention_mask)
+
+        return {
+            "logits": logits,
+            "tgt_output": tgt_output,
+            "c_mu": c_mu,
+            "c_log_var": c_log_var,
+            "s_mu": s_mu,
+            "s_log_var": s_log_var,
+            "z_c": z_c,
+            "z_s": z_s,
+        }
+
+
+# ──────────────────────────────────────────────────────────
+# Model construction helper
+# ──────────────────────────────────────────────────────────
+
+def build_model(config: ModelConfig, device: torch.device) -> VAETransformer:
+    """
+    Build the full VAE model: load LLaMA embeddings, construct architecture,
+    move to device, and print parameter counts.
+    """
+    print("Loading LLaMA embeddings...")
+    embedding_layer = load_llama_embeddings(config.llama_model_name)
+
+    print("Building VAETransformer...")
+    model = VAETransformer(config, embedding_layer).to(device)
+
+    # Parameter count breakdown
+    frozen = sum(p.numel() for p in model.parameters() if not p.requires_grad)
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    print(f"\nParameter counts:")
+    print(f"  Frozen (LLaMA embeddings): {frozen / 1e6:.1f}M")
+    print(f"  Trainable:                 {trainable / 1e6:.1f}M")
+    print(f"  Total:                     {(frozen + trainable) / 1e6:.1f}M")
+
+    return model

--- a/code/tst-training-v2/smoke_test.py
+++ b/code/tst-training-v2/smoke_test.py
@@ -1,0 +1,344 @@
+"""
+smoke_test.py — Verify that all modules wire together correctly.
+
+This test uses RANDOM embeddings (not real LLaMA weights) so it can run
+anywhere without GPU, HuggingFace login, or downloading the 1GB embedding
+shard. It validates:
+  1. Model construction and parameter counts
+  2. Forward pass shapes (encode → reparameterize → decode)
+  3. Loss computation (all 4 components)
+  4. Backward pass (gradients flow correctly)
+  5. Generation (autoregressive decoding)
+  6. Dataset and collate_fn shapes
+
+Run with:  python smoke_test.py
+"""
+
+import sys
+import torch
+import torch.nn as nn
+
+# Add parent to path so imports work
+sys.path.insert(0, ".")
+
+from config import ModelConfig, TrainConfig, DataConfig
+from model import VAETransformer, SinusoidalPositionalEncoding
+from losses import (
+    reconstruction_loss,
+    kl_divergence,
+    kl_anneal_factor,
+    hsic_loss,
+    contrastive_style_loss,
+    compute_total_loss,
+)
+from data import StyleDataset
+
+
+def make_dummy_model(config: ModelConfig) -> VAETransformer:
+    """Build model with random embeddings (no LLaMA download needed)."""
+    # Small vocab for testing
+    vocab_size = 1000
+    embed_dim = config.llama_embed_dim  # 4096
+
+    # Use a smaller embed dim for faster testing
+    test_embed_dim = 128
+    config_copy = ModelConfig(
+        llama_embed_dim=test_embed_dim,
+        d_model=64,
+        n_heads=4,
+        n_encoder_layers=2,
+        n_decoder_layers=2,
+        dim_feedforward=128,
+        content_latent_dim=32,
+        style_latent_dim=8,
+        max_seq_len=32,
+    )
+
+    embedding = nn.Embedding(vocab_size, test_embed_dim)
+    model = VAETransformer(config_copy, embedding)
+    return model, config_copy, vocab_size
+
+
+def test_model_construction():
+    """Test 1: Model builds without errors."""
+    print("Test 1: Model construction... ", end="")
+    model, config, vocab_size = make_dummy_model(ModelConfig())
+
+    # Check parameter groups
+    frozen = sum(p.numel() for p in model.parameters() if not p.requires_grad)
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    assert frozen > 0, "Embedding should be frozen"
+    assert trainable > 0, "Should have trainable parameters"
+
+    print(f"OK (trainable={trainable:,}, frozen={frozen:,})")
+
+
+def test_forward_pass():
+    """Test 2: Forward pass produces correct shapes."""
+    print("Test 2: Forward pass shapes... ", end="")
+    model, config, vocab_size = make_dummy_model(ModelConfig())
+    model.eval()
+
+    batch_size = 4
+    seq_len = 16
+    input_ids = torch.randint(0, vocab_size, (batch_size, seq_len))
+    attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
+    # Add some padding
+    attention_mask[:, -3:] = 0
+
+    with torch.no_grad():
+        outputs = model(input_ids, attention_mask)
+
+    assert outputs["logits"].shape == (batch_size, seq_len - 1, vocab_size), \
+        f"Logits shape wrong: {outputs['logits'].shape}"
+    assert outputs["tgt_output"].shape == (batch_size, seq_len - 1), \
+        f"Target shape wrong: {outputs['tgt_output'].shape}"
+    assert outputs["c_mu"].shape == (batch_size, config.content_latent_dim), \
+        f"c_mu shape wrong: {outputs['c_mu'].shape}"
+    assert outputs["s_mu"].shape == (batch_size, config.style_latent_dim), \
+        f"s_mu shape wrong: {outputs['s_mu'].shape}"
+    assert outputs["z_c"].shape == (batch_size, config.content_latent_dim)
+    assert outputs["z_s"].shape == (batch_size, config.style_latent_dim)
+
+    print("OK")
+
+
+def test_loss_computation():
+    """Test 3: All loss components compute without errors."""
+    print("Test 3: Loss computation... ", end="")
+    model, config, vocab_size = make_dummy_model(ModelConfig())
+
+    batch_size = 8
+    seq_len = 16
+    input_ids = torch.randint(0, vocab_size, (batch_size, seq_len))
+    attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
+    doc_ids = torch.tensor([0, 1, 0, 1, 0, 1, 0, 1])
+
+    outputs = model(input_ids, attention_mask)
+
+    loss, metrics = compute_total_loss(
+        logits=outputs["logits"],
+        tgt_output=outputs["tgt_output"],
+        pad_token_id=0,
+        c_mu=outputs["c_mu"],
+        c_log_var=outputs["c_log_var"],
+        s_mu=outputs["s_mu"],
+        s_log_var=outputs["s_log_var"],
+        z_c=outputs["z_c"],
+        z_s=outputs["z_s"],
+        doc_ids=doc_ids,
+        global_step=100,
+    )
+
+    assert loss.requires_grad, "Loss should require grad"
+    assert not torch.isnan(loss), "Loss is NaN"
+    assert not torch.isinf(loss), "Loss is Inf"
+
+    # Check all metric keys
+    expected_keys = {"loss", "recon", "kl_c", "kl_s", "kl_total", "beta", "hsic", "contrast"}
+    assert set(metrics.keys()) == expected_keys, f"Missing metrics: {expected_keys - set(metrics.keys())}"
+
+    print(f"OK (loss={loss.item():.4f})")
+
+
+def test_backward_pass():
+    """Test 4: Gradients flow through all trainable parameters."""
+    print("Test 4: Backward pass... ", end="")
+    model, config, vocab_size = make_dummy_model(ModelConfig())
+
+    batch_size = 4
+    seq_len = 16
+    input_ids = torch.randint(0, vocab_size, (batch_size, seq_len))
+    attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
+    doc_ids = torch.tensor([0, 1, 0, 1])
+
+    outputs = model(input_ids, attention_mask)
+    loss, _ = compute_total_loss(
+        logits=outputs["logits"],
+        tgt_output=outputs["tgt_output"],
+        pad_token_id=0,
+        c_mu=outputs["c_mu"],
+        c_log_var=outputs["c_log_var"],
+        s_mu=outputs["s_mu"],
+        s_log_var=outputs["s_log_var"],
+        z_c=outputs["z_c"],
+        z_s=outputs["z_s"],
+        doc_ids=doc_ids,
+        global_step=100,
+    )
+
+    loss.backward()
+
+    # Check that trainable params got gradients
+    grad_params = 0
+    no_grad_params = 0
+    for name, p in model.named_parameters():
+        if p.requires_grad:
+            if p.grad is not None and p.grad.abs().sum() > 0:
+                grad_params += 1
+            else:
+                no_grad_params += 1
+
+    # Embedding should NOT have gradients
+    assert model.embedding.weight.grad is None, "Frozen embedding should not have gradients"
+
+    print(f"OK ({grad_params} params with gradients, {no_grad_params} without)")
+
+
+def test_generation():
+    """Test 5: Autoregressive generation produces token sequences."""
+    print("Test 5: Generation... ", end="")
+    model, config, vocab_size = make_dummy_model(ModelConfig())
+    model.eval()
+
+    batch_size = 2
+    z = torch.randn(batch_size, config.total_latent_dim)
+
+    with torch.no_grad():
+        generated = model.decode_generate(
+            z=z,
+            bos_token_id=1,
+            eos_token_id=2,
+            pad_token_id=0,
+            max_len=20,
+        )
+
+    assert generated.shape[0] == batch_size, f"Batch dim wrong: {generated.shape}"
+    assert generated.shape[1] >= 2, f"Should generate at least BOS + 1 token: {generated.shape}"
+    assert generated[:, 0].tolist() == [1, 1], "First token should be BOS"
+
+    print(f"OK (generated shape: {generated.shape})")
+
+
+def test_kl_annealing():
+    """Test 6: KL annealing schedule produces correct values."""
+    print("Test 6: KL annealing... ", end="")
+
+    # β should be close to 0 at step 0
+    beta_0 = kl_anneal_factor(0, midpoint=5000, steepness=0.002)
+    assert beta_0 < 0.01, f"β at step 0 should be ~0, got {beta_0}"
+
+    # β should be ~0.5 at midpoint
+    beta_mid = kl_anneal_factor(5000, midpoint=5000, steepness=0.002)
+    assert abs(beta_mid - 0.5) < 0.01, f"β at midpoint should be ~0.5, got {beta_mid}"
+
+    # β should be close to 1 at 10000
+    beta_10k = kl_anneal_factor(10000, midpoint=5000, steepness=0.002)
+    assert beta_10k > 0.99, f"β at step 10000 should be ~1, got {beta_10k}"
+
+    print(f"OK (β at 0/5000/10000 = {beta_0:.4f}/{beta_mid:.4f}/{beta_10k:.4f})")
+
+
+def test_hsic():
+    """Test 7: HSIC properties — zero for independent, positive for dependent."""
+    print("Test 7: HSIC properties... ", end="")
+
+    # Independent vectors should have low HSIC
+    x = torch.randn(64, 32)
+    y = torch.randn(64, 8)
+    hsic_indep = hsic_loss(x, y).item()
+
+    # Dependent vectors (y is a function of x) should have higher HSIC
+    y_dep = x[:, :8] + 0.1 * torch.randn(64, 8)
+    hsic_dep = hsic_loss(x, y_dep).item()
+
+    assert hsic_dep > hsic_indep, \
+        f"HSIC should be higher for dependent data: {hsic_dep} vs {hsic_indep}"
+
+    print(f"OK (independent={hsic_indep:.4f}, dependent={hsic_dep:.4f})")
+
+
+def test_contrastive():
+    """Test 8: Contrastive loss is lower when same-style vectors are similar."""
+    print("Test 8: Contrastive loss... ", end="")
+
+    # Case 1: Random vectors (high loss)
+    z_random = torch.randn(8, 16)
+    doc_ids = torch.tensor([0, 0, 0, 0, 1, 1, 1, 1])
+    loss_random = contrastive_style_loss(z_random, doc_ids).item()
+
+    # Case 2: Clustered vectors (low loss)
+    z_clustered = torch.randn(8, 16)
+    z_clustered[:4] = z_clustered[:4] * 0.1 + torch.tensor([1.0] * 16)  # cluster 0
+    z_clustered[4:] = z_clustered[4:] * 0.1 + torch.tensor([-1.0] * 16)  # cluster 1
+    loss_clustered = contrastive_style_loss(z_clustered, doc_ids).item()
+
+    assert loss_clustered < loss_random, \
+        f"Clustered should have lower loss: {loss_clustered} vs {loss_random}"
+
+    print(f"OK (random={loss_random:.4f}, clustered={loss_clustered:.4f})")
+
+
+def test_dataset():
+    """Test 9: StyleDataset produces correct format."""
+    print("Test 9: Dataset format... ", end="")
+
+    data_config = DataConfig()
+    modern = ["I have half a mind to hit you.", "You are honest."]
+    original = ["I have a mind to strike thee.", "Thou art honest."]
+
+    dataset = StyleDataset(modern, original, data_config)
+
+    assert len(dataset) == 4, f"Should have 4 samples (2+2), got {len(dataset)}"
+
+    sample = dataset[0]
+    assert "text" in sample, "Sample missing 'text'"
+    assert "doc_id" in sample, "Sample missing 'doc_id'"
+    assert sample["doc_id"] == 0, "First sample should be modern (label=0)"
+    assert dataset[2]["doc_id"] == 1, "Third sample should be Shakespeare (label=1)"
+
+    print("OK")
+
+
+def test_weight_tying():
+    """Test 10: Output projection reuses embedding weights."""
+    print("Test 10: Weight tying... ", end="")
+    model, config, vocab_size = make_dummy_model(ModelConfig())
+
+    # The output path is: decoder_output → output_unproject → linear(embedding.weight)
+    # Check that embedding weight is used in _compute_logits
+    dummy_input = torch.randn(1, 5, config.d_model)
+    logits = model._compute_logits(dummy_input)
+    assert logits.shape == (1, 5, vocab_size), f"Logits shape wrong: {logits.shape}"
+
+    print("OK")
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("SMOKE TEST — VAE Text Style Transfer")
+    print("=" * 60)
+    print()
+
+    tests = [
+        test_model_construction,
+        test_forward_pass,
+        test_loss_computation,
+        test_backward_pass,
+        test_generation,
+        test_kl_annealing,
+        test_hsic,
+        test_contrastive,
+        test_dataset,
+        test_weight_tying,
+    ]
+
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            passed += 1
+        except Exception as e:
+            print(f"FAILED: {e}")
+            failed += 1
+
+    print()
+    print("=" * 60)
+    print(f"Results: {passed}/{passed + failed} tests passed")
+    if failed > 0:
+        print(f"  {failed} tests FAILED")
+        sys.exit(1)
+    else:
+        print("  All tests passed!")
+        sys.exit(0)

--- a/code/tst-training-v2/train.py
+++ b/code/tst-training-v2/train.py
@@ -1,0 +1,413 @@
+"""
+train.py — Training loop for the Text Style Transfer VAE.
+
+This is the main entry point. Run with:
+    python train.py
+
+Or from a notebook/SLURM script:
+    from train import train_model
+    train_model()
+
+Training procedure:
+═══════════════════
+1. Load LLaMA tokenizer + frozen embeddings
+2. Build non-parallel StyleDataset (modern label=0, Shakespeare label=1)
+3. For each epoch:
+   a. For each batch of mixed-style sentences:
+      - Tokenize on the fly (in collate_fn)
+      - Forward pass: encode → reparameterize → decode (teacher forcing)
+      - Compute total loss = recon + β·KL + γ·HSIC + λ·contrastive
+      - Backward pass + gradient clipping + optimizer step
+   b. Run validation loss
+   c. Save checkpoint if improved
+4. After final epoch: compute and save average style embeddings (for inference)
+
+The average style embeddings are the key to inference:
+  - Collect z_s for all training sentences
+  - Average z_s for modern sentences → avg_modern_style
+  - Average z_s for Shakespeare sentences → avg_shakespeare_style
+  - At inference: encode modern sentence → z_c, replace z_s with avg_shakespeare_style → decode
+
+This follows the same approach as John et al.'s avg_style_emb dict.
+"""
+
+import os
+import time
+from pathlib import Path
+
+# Redirect HuggingFace cache to project space to avoid home dir quota.
+# /projectnb has a much larger group quota than ~/.cache (~16GB home limit).
+_hf_cache = "/projectnb/scottml/seansal2/.cache/huggingface"
+os.makedirs(_hf_cache, exist_ok=True)
+os.environ.setdefault("HF_HOME", _hf_cache)
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader
+from transformers import AutoTokenizer
+
+from config import ModelConfig, TrainConfig, DataConfig
+from model import build_model, VAETransformer
+from data import build_dataloaders
+from losses import compute_total_loss
+
+
+# ──────────────────────────────────────────────────────────
+# Learning rate schedule: linear warmup + cosine decay
+# ──────────────────────────────────────────────────────────
+
+def get_lr_lambda(warmup_steps: int, total_steps: int, min_lr_ratio: float):
+    """
+    Returns a lambda for torch.optim.lr_scheduler.LambdaLR.
+
+    Phase 1 (step < warmup_steps): linear warmup from 0 to 1
+    Phase 2 (step >= warmup_steps): cosine decay from 1 to min_lr_ratio
+
+    This is the standard schedule used in most transformer training.
+    Warmup prevents early gradient explosions when the model is randomly
+    initialized and gradients are large.
+    """
+
+    def lr_lambda(step: int) -> float:
+        if step < warmup_steps:
+            # Linear warmup
+            return step / max(warmup_steps, 1)
+        else:
+            # Cosine decay
+            progress = (step - warmup_steps) / max(total_steps - warmup_steps, 1)
+            return min_lr_ratio + 0.5 * (1.0 - min_lr_ratio) * (1.0 + __import__("math").cos(progress * 3.14159))
+
+    return lr_lambda
+
+
+# ──────────────────────────────────────────────────────────
+# Compute average style embeddings (for inference)
+# ──────────────────────────────────────────────────────────
+
+@torch.no_grad()
+def compute_avg_style_embeddings(
+    model: VAETransformer,
+    dataloader: DataLoader,
+    device: torch.device,
+    num_styles: int = 2,
+) -> dict[int, torch.Tensor]:
+    """
+    After training, compute the average z_s for each style class.
+
+    These averages serve as "prototype" style vectors for inference.
+    To transfer a modern sentence to Shakespeare:
+      1. Encode modern sentence → z_c, z_s
+      2. Replace z_s with avg_shakespeare_style
+      3. Decode [z_c; avg_shakespeare_style] → Shakespeare output
+
+    Returns:
+        dict mapping style_label → average z_s tensor (style_latent_dim,)
+    """
+    model.eval()
+
+    style_sums = {i: None for i in range(num_styles)}
+    style_counts = {i: 0 for i in range(num_styles)}
+
+    print("Computing average style embeddings...")
+    for batch in dataloader:
+        input_ids = batch["input_ids"].to(device)
+        attention_mask = batch["attention_mask"].to(device)
+        doc_ids = batch["doc_ids"]
+
+        # Encode to get style latent
+        c_mu, c_log_var, s_mu, s_log_var = model.encode(input_ids, attention_mask)
+        # Use the mean (not sampled) for more stable prototypes
+        z_s = s_mu
+
+        for style_label in range(num_styles):
+            mask = (doc_ids == style_label)
+            if mask.any():
+                style_vectors = z_s[mask]  # (num_matched, style_latent_dim)
+                if style_sums[style_label] is None:
+                    style_sums[style_label] = style_vectors.sum(dim=0)
+                else:
+                    style_sums[style_label] += style_vectors.sum(dim=0)
+                style_counts[style_label] += mask.sum().item()
+
+    avg_style_embs = {}
+    for style_label in range(num_styles):
+        if style_counts[style_label] > 0:
+            avg_style_embs[style_label] = (
+                style_sums[style_label] / style_counts[style_label]
+            ).cpu()
+            print(f"  Style {style_label}: averaged over {style_counts[style_label]} sentences")
+        else:
+            print(f"  WARNING: No sentences found for style {style_label}")
+
+    return avg_style_embs
+
+
+# ──────────────────────────────────────────────────────────
+# Validation
+# ──────────────────────────────────────────────────────────
+
+@torch.no_grad()
+def validate(
+    model: VAETransformer,
+    dataloader: DataLoader,
+    device: torch.device,
+    pad_token_id: int,
+    global_step: int,
+    train_config: TrainConfig,
+) -> dict:
+    """Run validation and return average metrics."""
+    model.eval()
+    total_metrics = {}
+    num_batches = 0
+
+    for batch in dataloader:
+        input_ids = batch["input_ids"].to(device)
+        attention_mask = batch["attention_mask"].to(device)
+        doc_ids = batch["doc_ids"].to(device)
+
+        outputs = model(input_ids, attention_mask)
+
+        _, metrics = compute_total_loss(
+            logits=outputs["logits"],
+            tgt_output=outputs["tgt_output"],
+            pad_token_id=pad_token_id,
+            c_mu=outputs["c_mu"],
+            c_log_var=outputs["c_log_var"],
+            s_mu=outputs["s_mu"],
+            s_log_var=outputs["s_log_var"],
+            z_c=outputs["z_c"],
+            z_s=outputs["z_s"],
+            doc_ids=doc_ids,
+            global_step=global_step,
+            gamma_hsic=train_config.gamma_hsic,
+            lambda_contrast=train_config.lambda_contrast,
+            contrastive_temperature=train_config.contrastive_temperature,
+            kl_anneal_midpoint=train_config.kl_anneal_midpoint,
+            kl_anneal_steepness=train_config.kl_anneal_steepness,
+        )
+
+        for k, v in metrics.items():
+            total_metrics[k] = total_metrics.get(k, 0.0) + v
+        num_batches += 1
+
+    # Average
+    avg_metrics = {k: v / num_batches for k, v in total_metrics.items()}
+    return avg_metrics
+
+
+# ──────────────────────────────────────────────────────────
+# Main training function
+# ──────────────────────────────────────────────────────────
+
+def train_model(
+    model_config: ModelConfig | None = None,
+    train_config: TrainConfig | None = None,
+    data_config: DataConfig | None = None,
+):
+    """
+    Full training pipeline.
+
+    Can be called with custom configs or uses defaults.
+    """
+    if model_config is None:
+        model_config = ModelConfig()
+    if train_config is None:
+        train_config = TrainConfig()
+    if data_config is None:
+        data_config = DataConfig()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"Using device: {device}")
+
+    # ─── Tokenizer ───
+    print(f"\nLoading tokenizer: {model_config.llama_model_name}")
+    tokenizer = AutoTokenizer.from_pretrained(model_config.llama_model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    pad_token_id = tokenizer.pad_token_id
+
+    # ─── Model ───
+    model = build_model(model_config, device)
+
+    # ─── Data ───
+    print("\nBuilding dataloaders...")
+    loaders = build_dataloaders(
+        data_config=data_config,
+        model_config=model_config,
+        tokenizer=tokenizer,
+        batch_size=train_config.batch_size,
+    )
+    train_loader = loaders["train"]
+    valid_loader = loaders["valid"]
+
+    # ─── Optimizer ───
+    # Only optimize trainable parameters (frozen embeddings are excluded)
+    trainable_params = [p for p in model.parameters() if p.requires_grad]
+    optimizer = optim.AdamW(
+        trainable_params,
+        lr=train_config.learning_rate,
+        weight_decay=train_config.weight_decay,
+    )
+
+    # ─── LR scheduler ───
+    total_steps = len(train_loader) * train_config.num_epochs
+    lr_lambda = get_lr_lambda(
+        train_config.warmup_steps, total_steps, train_config.min_lr_ratio
+    )
+    scheduler = optim.lr_scheduler.LambdaLR(optimizer, lr_lambda)
+
+    # ─── Output directory ───
+    output_dir = Path(data_config.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # ─── Training loop ───
+    print(f"\nStarting training for {train_config.num_epochs} epochs")
+    print(f"  Batches per epoch: {len(train_loader)}")
+    print(f"  Total steps: {total_steps}")
+    print(f"  KL annealing midpoint: step {train_config.kl_anneal_midpoint}")
+    print()
+
+    global_step = 0
+    best_valid_loss = float("inf")
+
+    for epoch in range(train_config.num_epochs):
+        model.train()
+        epoch_start = time.time()
+        epoch_metrics = {}
+        num_batches = 0
+
+        for batch in train_loader:
+            input_ids = batch["input_ids"].to(device)
+            attention_mask = batch["attention_mask"].to(device)
+            doc_ids = batch["doc_ids"].to(device)
+
+            # Forward pass
+            outputs = model(input_ids, attention_mask)
+
+            # Compute loss
+            loss, metrics = compute_total_loss(
+                logits=outputs["logits"],
+                tgt_output=outputs["tgt_output"],
+                pad_token_id=pad_token_id,
+                c_mu=outputs["c_mu"],
+                c_log_var=outputs["c_log_var"],
+                s_mu=outputs["s_mu"],
+                s_log_var=outputs["s_log_var"],
+                z_c=outputs["z_c"],
+                z_s=outputs["z_s"],
+                doc_ids=doc_ids,
+                global_step=global_step,
+                gamma_hsic=train_config.gamma_hsic,
+                lambda_contrast=train_config.lambda_contrast,
+                contrastive_temperature=train_config.contrastive_temperature,
+                kl_anneal_midpoint=train_config.kl_anneal_midpoint,
+                kl_anneal_steepness=train_config.kl_anneal_steepness,
+            )
+
+            # Backward pass
+            optimizer.zero_grad()
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(trainable_params, train_config.max_grad_norm)
+            optimizer.step()
+            scheduler.step()
+
+            # Accumulate epoch metrics
+            for k, v in metrics.items():
+                epoch_metrics[k] = epoch_metrics.get(k, 0.0) + v
+            num_batches += 1
+
+            # ─── Periodic logging ───
+            if global_step % train_config.log_every == 0:
+                lr = scheduler.get_last_lr()[0]
+                print(
+                    f"  step {global_step:>6d} | "
+                    f"loss={metrics['loss']:.4f} | "
+                    f"recon={metrics['recon']:.4f} | "
+                    f"kl={metrics['kl_total']:.4f} (β={metrics['beta']:.3f}) | "
+                    f"hsic={metrics['hsic']:.4f} | "
+                    f"contrast={metrics['contrast']:.4f} | "
+                    f"lr={lr:.2e}"
+                )
+
+            # ─── Periodic validation ───
+            if global_step > 0 and global_step % train_config.eval_every == 0:
+                valid_metrics = validate(
+                    model, valid_loader, device, pad_token_id,
+                    global_step, train_config,
+                )
+                print(
+                    f"  [VALID] step {global_step} | "
+                    f"loss={valid_metrics['loss']:.4f} | "
+                    f"recon={valid_metrics['recon']:.4f} | "
+                    f"kl={valid_metrics['kl_total']:.4f}"
+                )
+
+                # Save best model
+                if valid_metrics["loss"] < best_valid_loss:
+                    best_valid_loss = valid_metrics["loss"]
+                    torch.save({
+                        "model_state_dict": model.state_dict(),
+                        "optimizer_state_dict": optimizer.state_dict(),
+                        "global_step": global_step,
+                        "epoch": epoch,
+                        "best_valid_loss": best_valid_loss,
+                        "model_config": model_config,
+                        "train_config": train_config,
+                    }, output_dir / "best_model.pt")
+                    print(f"  → Saved best model (valid_loss={best_valid_loss:.4f})")
+
+                model.train()  # Back to training mode
+
+            # ─── Periodic checkpoint ───
+            if global_step > 0 and global_step % train_config.save_every == 0:
+                torch.save({
+                    "model_state_dict": model.state_dict(),
+                    "optimizer_state_dict": optimizer.state_dict(),
+                    "scheduler_state_dict": scheduler.state_dict(),
+                    "global_step": global_step,
+                    "epoch": epoch,
+                    "model_config": model_config,
+                    "train_config": train_config,
+                }, output_dir / f"checkpoint_step{global_step}.pt")
+
+            global_step += 1
+
+        # End-of-epoch summary
+        epoch_time = time.time() - epoch_start
+        avg_metrics = {k: v / num_batches for k, v in epoch_metrics.items()}
+        print(
+            f"\nEpoch {epoch + 1}/{train_config.num_epochs} "
+            f"({epoch_time:.1f}s) | "
+            f"avg_loss={avg_metrics['loss']:.4f} | "
+            f"avg_recon={avg_metrics['recon']:.4f} | "
+            f"avg_kl={avg_metrics['kl_total']:.4f}"
+        )
+
+    # ─── Post-training: compute average style embeddings ───
+    print("\n" + "=" * 60)
+    print("Training complete. Computing average style embeddings...")
+    avg_style_embs = compute_avg_style_embeddings(
+        model, train_loader, device, num_styles=data_config.num_styles,
+    )
+
+    # Save everything needed for inference
+    torch.save({
+        "model_state_dict": model.state_dict(),
+        "avg_style_embs": avg_style_embs,
+        "model_config": model_config,
+        "train_config": train_config,
+        "data_config": data_config,
+        "global_step": global_step,
+    }, output_dir / "final_model.pt")
+    print(f"Saved final model + style embeddings to {output_dir / 'final_model.pt'}")
+
+    return model, avg_style_embs
+
+
+# ──────────────────────────────────────────────────────────
+# Entry point
+# ──────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    train_model()


### PR DESCRIPTION
Add VAE text style transfer training pipeline (tst-training-v2)

Merges data loading and frozen LLaMA 3.1 8B embedding extraction from
vae_style_transfer_starter with Scott's transformer VAE architecture
from transformer_vae_original into a clean, modular training pipeline.

Key changes from the original notebooks:
- Replaced cross-attention decoder with causal self-attention only,
  forcing all information through the latent bottleneck
- Replaced custom vocab with LLaMA BPE tokenizer (128K vocab)
- Replaced adversarial losses with HSIC + contrastive (InfoNCE)
- Added free bits and word dropout to combat posterior collapse